### PR TITLE
Update Rails

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org'
 
-gem 'rails', '~> 4.1.6'
+gem 'rails', '~> 4.1.13'
 gem 'pg'
 gem 'sass-rails', '~> 4.0.3'
 gem 'uglifier', '>= 1.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,27 +25,27 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    actionmailer (4.1.10)
-      actionpack (= 4.1.10)
-      actionview (= 4.1.10)
+    actionmailer (4.1.13)
+      actionpack (= 4.1.13)
+      actionview (= 4.1.13)
       mail (~> 2.5, >= 2.5.4)
-    actionpack (4.1.10)
-      actionview (= 4.1.10)
-      activesupport (= 4.1.10)
+    actionpack (4.1.13)
+      actionview (= 4.1.13)
+      activesupport (= 4.1.13)
       rack (~> 1.5.2)
       rack-test (~> 0.6.2)
-    actionview (4.1.10)
-      activesupport (= 4.1.10)
+    actionview (4.1.13)
+      activesupport (= 4.1.13)
       builder (~> 3.1)
       erubis (~> 2.7.0)
-    activemodel (4.1.10)
-      activesupport (= 4.1.10)
+    activemodel (4.1.13)
+      activesupport (= 4.1.13)
       builder (~> 3.1)
-    activerecord (4.1.10)
-      activemodel (= 4.1.10)
-      activesupport (= 4.1.10)
+    activerecord (4.1.13)
+      activemodel (= 4.1.13)
+      activesupport (= 4.1.13)
       arel (~> 5.0.0)
-    activesupport (4.1.10)
+    activesupport (4.1.13)
       i18n (~> 0.6, >= 0.6.9)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -175,7 +175,7 @@ GEM
       thor (>= 0.14, < 2.0)
     jquery-ui-rails (5.0.3)
       railties (>= 3.2.16)
-    json (1.8.2)
+    json (1.8.3)
     jwt (1.4.1)
     kaminari (0.16.3)
       actionpack (>= 3.0.0)
@@ -184,10 +184,10 @@ GEM
     libv8 (3.16.14.7)
     mail (2.6.3)
       mime-types (>= 1.16, < 3)
-    mime-types (2.5)
+    mime-types (2.6.2)
     mini_portile (0.6.2)
-    minitest (5.6.0)
-    multi_json (1.11.0)
+    minitest (5.8.2)
+    multi_json (1.11.2)
     multi_xml (0.5.5)
     multipart-post (2.0.0)
     newrelic_rpm (3.11.2.286)
@@ -214,22 +214,22 @@ GEM
     procto (0.0.2)
     quiet_assets (1.1.0)
       railties (>= 3.1, < 5.0)
-    rack (1.5.2)
+    rack (1.5.5)
     rack-attack (4.2.0)
       rack
     rack-protection (1.5.3)
       rack
     rack-test (0.6.3)
       rack (>= 1.0)
-    rails (4.1.10)
-      actionmailer (= 4.1.10)
-      actionpack (= 4.1.10)
-      actionview (= 4.1.10)
-      activemodel (= 4.1.10)
-      activerecord (= 4.1.10)
-      activesupport (= 4.1.10)
+    rails (4.1.13)
+      actionmailer (= 4.1.13)
+      actionpack (= 4.1.13)
+      actionview (= 4.1.13)
+      activemodel (= 4.1.13)
+      activerecord (= 4.1.13)
+      activesupport (= 4.1.13)
       bundler (>= 1.3.0, < 2.0)
-      railties (= 4.1.10)
+      railties (= 4.1.13)
       sprockets-rails (~> 2.0)
     rails_12factor (0.0.3)
       rails_serve_static_assets
@@ -245,9 +245,9 @@ GEM
       ruby-progressbar
     rails_serve_static_assets (0.0.4)
     rails_stdout_logging (0.0.3)
-    railties (4.1.10)
-      actionpack (= 4.1.10)
-      activesupport (= 4.1.10)
+    railties (4.1.13)
+      actionpack (= 4.1.13)
+      activesupport (= 4.1.13)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rainbow (2.0.0)
@@ -333,7 +333,7 @@ GEM
       multi_json (~> 1.0)
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
-    sprockets-rails (2.2.4)
+    sprockets-rails (2.3.3)
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
@@ -409,7 +409,7 @@ DEPENDENCIES
   procto
   quiet_assets
   rack-attack
-  rails (~> 4.1.6)
+  rails (~> 4.1.13)
   rails_12factor
   rails_best_practices
   rake
@@ -434,3 +434,6 @@ DEPENDENCIES
   virtus
   webmock
   yard!
+
+BUNDLED WITH
+   1.10.6


### PR DESCRIPTION
Currently, RefactorCop is defaulting to an insecure Rails version.

This update increases that to the current version of the `4.1.x` branch - previously we were requiring a minimum of `4.1.6` and `Gemfile.lock` was locked to `4.1.10`.

Both of the above versions are insecure (see, for example, [CVE-2015-3226](https://groups.google.com/forum/#!msg/rubyonrails-security/7VlB_pck3hU/3QZrGIaQW6cJ) and [CVE-2015-3227](https://groups.google.com/forum/#!msg/rubyonrails-security/bahr2JLnxvk/x4EocXnHPp8J)).